### PR TITLE
updated composer - laminas-form version to ^3.1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "squizlabs/php_codesniffer": "^3.5",
         "dotkernel/dot-navigation": "^3.1",
         "dotkernel/dot-flashmessenger": "^3.1.1",
-        "laminas/laminas-form": "^2.15",
+        "laminas/laminas-form": "^3.1.1",
         "doctrine/doctrine-module": "^4.0",
         "laminas/laminas-dependency-plugin": "^2.1",
         "mezzio/mezzio-authorization": "^1.0"


### PR DESCRIPTION
related to https://github.com/dotkernel/dot-twigrenderer/issues/10
must be tested with _composer install_ on working project
note: the requirement is in _require-dev_